### PR TITLE
Adding SDK class WebDriverWait to support proper reporting of expected conditions applied to it.

### DIFF
--- a/src/testproject/classes/__init__.py
+++ b/src/testproject/classes/__init__.py
@@ -3,6 +3,7 @@ from .elementsearchcriteria import ElementSearchCriteria
 from .proxydescriptor import ProxyDescriptor
 from .step_settings import StepSettings
 from .driver_step_settings import DriverStepSettings
+from .web_driver_wait import TestProjectWebDriverWait as WebDriverWait
 
 __all__ = ["ActionExecutionResponse", "ElementSearchCriteria", "ProxyDescriptor", "StepSettings",
-           "DriverStepSettings"]
+           "DriverStepSettings", "WebDriverWait"]

--- a/src/testproject/classes/web_driver_wait.py
+++ b/src/testproject/classes/web_driver_wait.py
@@ -1,0 +1,148 @@
+import os
+import json
+from typing import Union
+
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support.wait import WebDriverWait
+
+from src.testproject.classes import DriverStepSettings, StepSettings
+from src.testproject.sdk.drivers.webdriver import Remote
+from src.testproject.sdk.drivers.webdriver.base import BaseDriver
+
+
+class TestProjectWebDriverWait(WebDriverWait):
+    """Wrapper class for the WebDriverWait.
+
+    WebDriverWait uses until/until_not functions, these functions can call a certain driver command more than once.
+    Moreover, the evaluated step result doesn't have to match the result of the driver command.
+    For Example:
+        until(title_is(title)) will execute driver.title which in itself will work (as a driver command)
+        but that doesnt guarantee that the title is the expected title.
+    Due to the above, this wrapper class handles the step reporting and user defined step settings.
+
+    Args:
+        driver: that this WebDriverWait instance will use to execute commands.
+        timeout: is the WebDriverWait timeout to wait for expected condition before raising TimeoutException.
+
+    """
+    def __init__(self, driver: Union[BaseDriver, Remote], timeout):
+        super().__init__(driver, timeout)
+        self._driver = driver
+
+    def until(self, method, message=''):
+        """Executes the wrapping function for until."""
+        return self.execute("until", method, message)
+
+    def until_not(self, method, message=''):
+        """Executes the wrapping function for until_not."""
+        return self.execute("until_not", method, message)
+
+    def execute(self, function_name, method, message):
+        """Executes the function (until/until_not) silently (without reports/settings).
+
+        This execution will take into account the defined step settings and will handle them only once before silently
+        executing the function.
+        Based on the function's result and given method, it will report this Step with all the needed information.
+        Returns the result of the executed function.
+        """
+        timeout_exception = None
+        step_helper = self.driver.command_executor.step_helper
+        step_settings = self.driver.command_executor.settings
+        # Save current disable_reports value and disable reports before executing the wait function.
+        reports_disabled = self._driver.command_executor.disable_reports
+        self._driver.report().disable_reports(True)
+        # Handle driver timeout
+        step_helper.handle_timeout(timeout=step_settings.timeout)
+        # Handle sleep before
+        step_helper.handle_sleep(sleep_timing_type=step_settings.sleep_timing_type,
+                                 sleep_time=step_settings.sleep_time)
+        # Execute the function with default StepSettings.
+        with DriverStepSettings(self._driver, StepSettings()):
+            try:
+                result = getattr(super(), function_name)(method, message)
+            except TimeoutException as e:
+                result = False
+                timeout_exception = e
+        # Handle sleep after
+        step_helper.handle_sleep(sleep_timing_type=step_settings.sleep_timing_type,
+                                 sleep_time=step_settings.sleep_time, step_executed=True)
+        # Handle result
+        result, step_message = step_helper.handle_step_result(step_result=result,
+                                                              invert_result=step_settings.invert_result,
+                                                              always_pass=step_settings.always_pass)
+        # Handle screenshot condition
+        screenshot = step_helper.take_screenshot(step_settings.screenshot_condition, result)
+
+        # Set the previous value of disable_reports.
+        self._driver.report().disable_reports(reports_disabled)
+
+        # Inferring function name - until / until not
+        function_name = ' '.join(function_name.split('_'))
+        # Getting all additional step information.
+        step_name, step_attributes = self.get_report_details(method)
+        self._driver.report().step(description=f'Wait {function_name} {step_name}',
+                                   message=f'{step_message}{os.linesep}',
+                                   passed=result,
+                                   inputs=step_attributes,
+                                   screenshot=screenshot)
+        # Always pass ignore result and thrown exception.
+        if step_settings.always_pass:
+            return True
+        # Raise exception if there was one.
+        if timeout_exception:
+            raise timeout_exception
+        return result
+
+    def get_report_details(self, method):
+        """Returns the inferred report details.
+
+        Attributes:
+            method: is a callable expected condition class.
+
+        Examples:
+            Assuming the method sent to the WebDriverWait's wait function is title_is(title="some title")...
+            The method class is name 'title_is' and the returned step_name will be 'title is'
+            The method attributes dict will be {"title": "some title"}
+
+        Returns:
+            step_name (str): The method class's name, underscores are replaces with spaces.
+            attributes_dict (dict): is all the method's attributes and their values.
+
+        """
+        step_name = ' '.join(method.__class__.__name__.split('_'))
+        attributes_dict = {attribute: json.dumps(getattr(method, attribute))
+                           for attribute in self.get_user_attributes(method)}
+        return step_name, attributes_dict
+
+    @staticmethod
+    def get_user_attributes(cls, exclude_methods=True) -> list:
+        """Gets a class's user defined attributes, ignores methods by default.
+
+        Examples:
+            Assuming we have the following class
+                class Foo:
+                    def __init__(self):
+                        self.a = 1
+                        self.b = 2
+
+                    def some_foo(self):
+                        pass
+
+            This function will return a list of ["a", "b"] and will ignore method 'some_foo' by default.
+
+        Returns a list of all user defined attributes in the class.
+
+        """
+        base_attrs = dir(type('dummy', (object,), {}))
+        this_cls_attrs = dir(cls)
+        res = []
+        for attr in this_cls_attrs:
+            if base_attrs.count(attr) or (callable(getattr(cls, attr)) and exclude_methods):
+                continue
+            res += [attr]
+        return res
+
+    @property
+    def driver(self):
+        """Getter for the driver."""
+        return self._driver

--- a/tests/ci/headless/chrome_web_driver_wait_test.py
+++ b/tests/ci/headless/chrome_web_driver_wait_test.py
@@ -1,0 +1,67 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+
+from src.testproject.classes import WebDriverWait, DriverStepSettings, StepSettings
+from src.testproject.enums import TakeScreenshotConditionType
+from selenium.webdriver.support import expected_conditions as ec
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver import ChromeOptions
+
+from tests.pageobjects.web import LoginPage, ProfilePage
+
+
+@pytest.fixture
+def driver():
+    chrome_options = ChromeOptions()
+    chrome_options.headless = True
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
+    yield driver
+    driver.quit()
+
+
+@pytest.fixture()
+def wait(driver):
+    wait = WebDriverWait(driver, 2)  # Notice the imports, using WebDriverWait from 'src.testproject.classes'
+    yield wait
+
+
+def test_wait_with_ec_invisible(driver, wait):
+    # Case 1 - Should report passed.
+    LoginPage(driver).open().login_as("John Smith", "12345")
+    # Check successful login.
+    assert ProfilePage(driver).greetings_are_displayed() is True
+    ProfilePage(driver).logout()
+    # Greeting label shouldn't be shown anymore after logout.
+    textlabel_greetings = (By.CSS_SELECTOR, "#greetings")
+    element_not_present = wait.until(ec.invisibility_of_element_located(textlabel_greetings))
+    assert element_not_present
+    # Case 2 - Should report failed.
+    try:
+        wait.until(ec.title_is("Title that is definitely not this one."))
+    except TimeoutException:
+        pass
+    # Case 3 - Report with StepSettings
+    # Inverting result and taking picture on success.
+    # Wait should timeout and report fail which will be inverted to passed and include picture.
+    with DriverStepSettings(driver=wait.driver,
+                            step_settings=StepSettings(invert_result=True,
+                                                       screenshot_condition=TakeScreenshotConditionType.Failure)):
+        try:
+            wait.until_not(ec.url_contains("TestProject"))
+        except TimeoutException:
+            pass

--- a/tests/examples/web_driver_wait/web_driver_wait_test.py
+++ b/tests/examples/web_driver_wait/web_driver_wait_test.py
@@ -1,0 +1,56 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+# Notice we import WebDriverWait from SDK classes!
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+
+from src.testproject.classes import WebDriverWait
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver.support import expected_conditions as ec
+
+from tests.pageobjects.web import LoginPage, ProfilePage
+
+
+@pytest.fixture
+def driver():
+    driver = webdriver.Chrome()
+    yield driver
+    driver.quit()
+
+
+@pytest.fixture()
+def wait(driver):
+    wait = WebDriverWait(driver, 2)  # Notice the imports, using WebDriverWait from 'src.testproject.classes'
+    yield wait
+
+
+def test_wait_with_ec_invisible(driver, wait):
+    # Driver command will fail because element will not be found but this is the expected result so this step actually
+    # passes and will reported as passed as well.
+    LoginPage(driver).open().login_as("John Smith", "12345")
+    # Check successful login.
+    assert ProfilePage(driver).greetings_are_displayed() is True
+    ProfilePage(driver).logout()
+    # Greeting label shouldn't be shown anymore after logout.
+    textlabel_greetings = (By.CSS_SELECTOR, "#greetings")
+    element_not_present = wait.until(ec.invisibility_of_element_located(textlabel_greetings))
+    assert element_not_present
+    # This step will fail because the example page's title is not the one we give below, step will be reported as failed
+    # and a TimeoutException will arose by the WebDriverWait instance.
+    try:
+        wait.until(ec.title_is("Title that is definitely not this one."))
+    except TimeoutException:
+        pass

--- a/tests/internal/web_driver_wait_test.py
+++ b/tests/internal/web_driver_wait_test.py
@@ -1,0 +1,53 @@
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from src.testproject.classes import DriverStepSettings, StepSettings, WebDriverWait
+from src.testproject.enums import TakeScreenshotConditionType
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as ec
+
+from tests.pageobjects.web import LoginPage, ProfilePage
+
+DEV_TOKEN = "ZNXf2v22_eXli4w4UsLM5ulkfxLHK1IqNSfHH7i2wyI1"
+
+
+@pytest.fixture
+def driver():
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Web Driver Report Project",
+                              job_name="Web Driver Report Job")
+    yield driver
+    driver.quit()
+
+
+@pytest.fixture()
+def wait(driver):
+    wait = WebDriverWait(driver, 2)  # Notice the imports, using WebDriverWait from 'src.testproject.classes'
+    yield wait
+
+
+def test_wait_with_ec_invisible(driver, wait):
+    # Case 1 - Should report passed.
+    LoginPage(driver).open().login_as("John Smith", "12345")
+    # Check successful login.
+    assert ProfilePage(driver).greetings_are_displayed() is True
+    ProfilePage(driver).logout()
+    # Greeting label shouldn't be shown anymore after logout.
+    textlabel_greetings = (By.CSS_SELECTOR, "#greetings")
+    element_not_present = wait.until(ec.invisibility_of_element_located(textlabel_greetings))
+    assert element_not_present
+    # Case 2 - Should report failed.
+    try:
+        wait.until(ec.title_is("Title that is definitely not this one."))
+    except TimeoutException:
+        pass
+    # Case 3 - Report with StepSettings
+    # Inverting result and taking picture on success.
+    # Wait should timeout and report fail which will be inverted to passed and include picture.
+    with DriverStepSettings(driver=wait.driver,
+                            step_settings=StepSettings(invert_result=True,
+                                                       screenshot_condition=TakeScreenshotConditionType.Failure)):
+        try:
+            wait.until_not(ec.url_contains("TestProject"))
+        except TimeoutException:
+            pass


### PR DESCRIPTION
The example shows all the information the user needs in order to use the SDK's WebDriverWait instead of Selenium's WebDriverWait class.

The SDK's WebDriverWait wraps Selenium's WebDriverWait class just like a decorator wraps a function.

It takes into consideration all StepSettings applied on the driver.
In addition, it knows how to silently execute the same methods by disabling automatic reporting in the driver.
After a silent execution, it takes the method's result, infers all the execution information (fields, expected condition method name and the method used by the WebDriverWait) and reports it manually according to the result of the WebDriverWait.

**Previously**, the result of the step got reported automatically by the driver in accordance to the success of the driver command.
This is wrong for WebDriverWait in general because the expected condition is not necessarily the same as the driver command succession.