### PR TITLE
Adding class attribute 'session_id' to the StepHelper class - Fixes handle_timeout method.

### DIFF
--- a/src/testproject/helpers/addonhelper.py
+++ b/src/testproject/helpers/addonhelper.py
@@ -47,7 +47,7 @@ class AddonHelper:
         step_helper = self._command_executor.step_helper
 
         # Handling driver timeout
-        step_helper.handle_timeout(settings.timeout, self._agent_client.agent_session.session_id)
+        step_helper.handle_timeout(settings.timeout)
         # Handling sleep before execution
         step_helper.handle_sleep(sleep_timing_type=settings.sleep_timing_type, sleep_time=settings.sleep_time)
 

--- a/src/testproject/helpers/step_helper.py
+++ b/src/testproject/helpers/step_helper.py
@@ -23,17 +23,18 @@ from src.testproject.enums import SleepTimingType, TakeScreenshotConditionType
 
 class StepHelper:
 
-    def __init__(self, executor: RemoteConnection, w3c: bool):
+    def __init__(self, executor: RemoteConnection, w3c: bool, session_id: str):
         self.executor = executor
         self.w3c = w3c
+        self.session_id = session_id
 
-    def handle_timeout(self, timeout, session_id):
+    def handle_timeout(self, timeout):
         if timeout > 0:
             logging.debug(f'Setting driver implicit wait to {timeout} milliseconds.')
             if self.w3c:
-                self.executor.execute(Command.SET_TIMEOUTS, {'sessionId': session_id, 'implicit': int(timeout)})
+                self.executor.execute(Command.SET_TIMEOUTS, {'sessionId': self.session_id, 'implicit': int(timeout)})
             else:
-                self.executor.execute(Command.IMPLICIT_WAIT, {'sessionId': session_id, 'ms': float(timeout)})
+                self.executor.execute(Command.IMPLICIT_WAIT, {'sessionId': self.session_id, 'ms': float(timeout)})
 
     @staticmethod
     def handle_sleep(sleep_timing_type, sleep_time, command=None, step_executed=False):

--- a/src/testproject/sdk/internal/helpers/custom_appium_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/custom_appium_command_executor.py
@@ -43,13 +43,13 @@ class CustomAppiumCommandExecutor(AppiumConnection, ReportingCommandExecutor):
             skip_reporting (bool): True if command should not be reported to Agent, False otherwise
 
         Returns:
-            response: Response returned by the Selenium remote webdriver server
+            response: Response returned by the Selenium remote WebDriver server
         """
         self.update_known_test_name()
 
         response = {}
 
-        self.step_helper.handle_timeout(self.settings.timeout, self.agent_client.agent_session.session_id)
+        self.step_helper.handle_timeout(self.settings.timeout)
 
         # Handling sleep before execution
         self.step_helper.handle_sleep(self.settings.sleep_timing_type, self.settings.sleep_time, command)

--- a/src/testproject/sdk/internal/helpers/custom_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/custom_command_executor.py
@@ -42,11 +42,11 @@ class CustomCommandExecutor(RemoteConnection, ReportingCommandExecutor):
             skip_reporting (bool): True if command should not be reported to Agent, False otherwise
 
         Returns:
-            response: Response returned by the Selenium remote webdriver server
+            response: Response returned by the Selenium remote WebDriver server
         """
         self.update_known_test_name()
 
-        self.step_helper.handle_timeout(self.settings.timeout, self.agent_client.agent_session.session_id)
+        self.step_helper.handle_timeout(self.settings.timeout)
 
         # Handling sleep before execution
         self.step_helper.handle_sleep(self.settings.sleep_timing_type, self.settings.sleep_time, command)

--- a/src/testproject/sdk/internal/helpers/reporting_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/reporting_command_executor.py
@@ -55,7 +55,8 @@ class ReportingCommandExecutor:
         self._stashed_command = None
         self._latest_known_test_name = ReportHelper.infer_test_name()
         self._excluded_test_names = list()
-        self._step_helper = StepHelper(remote_connection, agent_client.agent_session.dialect == "W3C")
+        self._step_helper = StepHelper(remote_connection, agent_client.agent_session.dialect == "W3C",
+                                       agent_client.agent_session.session_id)
         self._settings = StepSettings()
 
     @property


### PR DESCRIPTION
Adding this attribute to the class instead of passing this attribute to the handle_timeout method for every call on the method.