### PR TITLE
Avoid SdkException if no active driver while attempting to initialize agent client

### DIFF
--- a/src/testproject/decorator/behave_reporter.py
+++ b/src/testproject/decorator/behave_reporter.py
@@ -16,6 +16,8 @@ from src.testproject.helpers.activesessionhelper import get_active_driver_instan
 
 from functools import wraps
 from src.testproject.enums import EnvironmentVariable
+from src.testproject.sdk.exceptions import SdkException
+import logging
 import os
 
 
@@ -32,26 +34,34 @@ def behave_reporter(func=None, *, screenshot: bool = False):
             # Disable automatic test and command reporting.
             if os.getenv("TP_DISABLE_AUTO_REPORTING") != "True":
                 os.environ[EnvironmentVariable.TP_DISABLE_AUTO_REPORTING.value] = "True"
-            # Update job name as soon as possible.
-            context = args[0]
-            # Check if the context has a feature attribute which is not None to avoid error when decorator
-            # is used on a method with a different param.
-            if hasattr(context, 'feature') and context.feature and not hasattr(context, 'tp_job_name_updated'):
-                # Update the job name
-                context.tp_job_name_updated = True
-                # noinspection PyProtectedMember
-                get_active_driver_instance()._agent_client.update_job_name(context.feature.name)
-            # Report step or test based on the constant hook name.
-            # Behave always calls the methods with the arguments in the following order: (context, step/scenario).
-            hook_name = _func.__name__
-            if hook_name == "after_step":
+
+            driver = None
+            try:
                 driver = get_active_driver_instance()
-                step = args[1]
-                report_step(driver=driver, step=step, screenshot=screenshot)
-            if hook_name == "after_scenario":
-                driver = get_active_driver_instance()
-                scenario = args[1]
-                report_test(driver=driver, scenario=scenario)
+            except SdkException as err:
+                logging.error(f"No valid WebDriver found: {err} - Reports are disabled!")
+
+            if driver is not None:
+
+                # Update job name as soon as possible.
+                context = args[0]
+                # Check if the context has a feature attribute which is not None to avoid error when decorator
+                # is used on a method with a different param.
+                if hasattr(context, 'feature') and context.feature and not hasattr(context, 'tp_job_name_updated'):
+                    # Update the job name
+                    driver.update_job_name(context.feature.name)
+                    context.tp_job_name_updated = True
+
+                # Report step or test based on the constant hook name.
+                # Behave always calls the methods with the arguments in the following order: (context, step/scenario).
+                hook_name = _func.__name__
+                if hook_name == "after_step":
+                    step = args[1]
+                    report_step(driver=driver, step=step, screenshot=screenshot)
+                if hook_name == "after_scenario":
+                    scenario = args[1]
+                    report_test(driver=driver, scenario=scenario)
+
             return _func(*args, **kwargs)
         return wrapper
 

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -154,6 +154,14 @@ class BaseDriver(RemoteWebDriver):
     def pause(self, milliseconds: int):
         self.command_executor.pause(milliseconds)
 
+    def update_job_name(self, job_name):
+        """Updates the job name of the execution during runtime
+
+        Args:
+            job_name (str): updated job name to set for the execution.
+        """
+        self._agent_client.update_job_name(job_name=job_name)
+
     def quit(self):
         """Quits the driver and stops the session with the Agent, cleaning up after itself"""
         # Report any left over driver command reports

--- a/src/testproject/sdk/drivers/webdriver/generic.py
+++ b/src/testproject/sdk/drivers/webdriver/generic.py
@@ -127,6 +127,14 @@ class Generic:
         """
         return AddonHelper(self._agent_client, self.command_executor)
 
+    def update_job_name(self, job_name):
+        """Updates the job name of the execution during runtime
+
+        Args:
+            job_name (str): updated job name to set for the execution.
+        """
+        self._agent_client.update_job_name(job_name=job_name)
+
     def quit(self):
         """Quits the driver and stops the session with the Agent, cleaning up after itself."""
         # Report any left over driver command reports

--- a/src/testproject/sdk/drivers/webdriver/remote.py
+++ b/src/testproject/sdk/drivers/webdriver/remote.py
@@ -148,6 +148,14 @@ class Remote(AppiumWebDriver):
     def pause(self, milliseconds: int):
         self.command_executor.pause(milliseconds)
 
+    def update_job_name(self, job_name):
+        """Updates the job name of the execution during runtime
+
+        Args:
+            job_name (str): updated job name to set for the execution.
+        """
+        self._agent_client.update_job_name(job_name=job_name)
+
     def quit(self):
         """Quits the driver and stops the session with the Agent, cleaning up after itself."""
         # Report any left over driver command reports


### PR DESCRIPTION
The get_active_driver_instance method raises an SDK exception if no client is initialized, avoid an exception
while attempting to update the job name if no client has been initialized yet.

This happens in cases such as using the behave_reporter decorator on a before_scenario hook, where there is a context attribute 
with an active feature running, but the driver has not been initialized yet before attempting to update a job name.