### PR TITLE
Avoid iterating NoneType when addon execution response's 'fields' key is None.

### DIFF
--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -429,7 +429,8 @@ class AgentClient:
                                                              if operation_result.data["resultType"] == "Passed"
                                                              else ExecutionResultType.Failed),
                                       message=operation_result.data["message"],
-                                      fields=[ResultField(**field) for field in operation_result.data['fields']])
+                                      fields=([] if not operation_result.data['fields']
+                                              else [ResultField(**field) for field in operation_result.data['fields']]))
 
     @staticmethod
     def _create_action_proxy_payload(action: ActionProxy) -> dict:


### PR DESCRIPTION
This is done to prevent an iteration over a NoneType.

Closing #144 

Signed-off-by: Tzah Mazuz <tzah.mazuz@testproject.io>