### PR TITLE
Allow controlling report type - local / cloud or both

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0] - 2021-03-29
+
+### Added
+
+- ([#149](https://github.com/testproject-io/python-opensdk/pull/149)) - Allow controlling report type - local / cloud or both.
+
 ## [0.65.3] - 2021-03-18
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -413,6 +413,25 @@ Upon calling ``quit()``, the SDK will send all remaining report items to the Age
         def tearDown(self):
             self.driver.quit()
 
+Cloud and Local Report
+----------------------
+By default, the execution report is uploaded to the cloud, and a local report is created, as an HTML file in a temporary folder.
+
+At the end of execution, the report is uploaded to the cloud and SDK outputs to the console/terminal the path for a local report file:
+
+`Execution Report: {temporary_folder}/report.html`
+
+This behavior can be controlled, by requesting only a `LOCAL` or only a `CLOUD` report.
+
+    When the Agent is offline, and only a _cloud_ report is requested, execution will fail with appropriate message.
+
+Via a driver constructor:
+
+.. code-block:: python
+
+    driver = webdriver.Chrome(report_type=ReportType.LOCAL)
+
+
 Logging
 -------
 The TestProject Python SDK uses the ``logging`` framework built into Python.

--- a/src/testproject/enums/report_type.py
+++ b/src/testproject/enums/report_type.py
@@ -1,0 +1,21 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from enum import Enum
+
+
+class ReportType(Enum):
+    """Enum specifying the execution's report type."""
+    CLOUD = 0
+    LOCAL = 1
+    CLOUD_AND_LOCAL = 2

--- a/src/testproject/enums/reportnamingelement.py
+++ b/src/testproject/enums/reportnamingelement.py
@@ -18,7 +18,6 @@ from enum import Enum, unique
 @unique
 class ReportNamingElement(Enum):
     """Enum containing types of report elements that can be inferred"""
-
     Project = 1
     Job = 2
     Test = 3

--- a/src/testproject/rest/messages/sessionrequest.py
+++ b/src/testproject/rest/messages/sessionrequest.py
@@ -29,6 +29,7 @@ class SessionRequest:
         _language (str): Test code language (Python, obviously)
         _project_name (str): Project name to report
         _job_name (str): Job name to report
+        _report_type (ReportType): Report type = cloud, local or both.
     """
 
     def __init__(self, capabilities: dict, report_settings: ReportSettings):
@@ -37,6 +38,7 @@ class SessionRequest:
         self._language = "Python"
         self._project_name = report_settings.project_name
         self._job_name = report_settings.job_name
+        self._report_type = report_settings.report_type
 
     def to_json(self):
         """Returns a JSON representation of the current SessionRequest instance"""
@@ -46,4 +48,5 @@ class SessionRequest:
             "capabilities": self._capabilities,
             "sdkVersion": self._sdk_version,
             "language": self._language,
+            "reportType": self._report_type.name
         }

--- a/src/testproject/rest/messages/sessionresponse.py
+++ b/src/testproject/rest/messages/sessionresponse.py
@@ -33,21 +33,15 @@ class SessionResponse:
         _agent_version (str): Agent version, required to check backwards compatibility
     """
 
-    def __init__(
-        self,
-        dev_socket_port: int,
-        server_address: str,
-        session_id: str,
-        dialect: str,
-        capabilities: dict,
-        agent_version: str,
-    ):
+    def __init__(self, dev_socket_port: int, server_address: str, session_id: str, dialect: str, capabilities: dict,
+                 agent_version: str, local_report: str):
         self._dev_socket_port = dev_socket_port
         self._server_address = server_address
         self._session_id = session_id
         self._dialect = dialect
         self._capabilities = capabilities
         self._agent_version = agent_version
+        self._local_report = local_report
 
     @property
     def dev_socket_port(self) -> int:
@@ -78,3 +72,8 @@ class SessionResponse:
     def agent_version(self) -> str:
         """Getter for the Agent version"""
         return self._agent_version
+
+    @property
+    def local_report(self) -> str:
+        """Getter for the Local Report"""
+        return self._local_report

--- a/src/testproject/rest/reportsettings.py
+++ b/src/testproject/rest/reportsettings.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from src.testproject.enums.report_type import ReportType
+
 
 class ReportSettings:
     """Contains settings to be used in the report.
@@ -19,15 +21,18 @@ class ReportSettings:
         Args:
             project_name (str): Project name to report
             job_name (str): Job name to report
+            report_type (Optional[ReportType]): Report type = cloud, local or both.
 
         Attributes:
             _project_name (str): Project name to report
             _job_name (str): Job name to report
+            _report_type (ReportType): Report type = cloud, local or both.
     """
 
-    def __init__(self, project_name: str, job_name: str):
+    def __init__(self, project_name: str, job_name: str, report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
         self._project_name = project_name
         self._job_name = job_name
+        self._report_type = report_type
 
     @property
     def project_name(self) -> str:
@@ -39,13 +44,20 @@ class ReportSettings:
         """Getter for the job name"""
         return self._job_name
 
+    @property
+    def report_type(self) -> ReportType:
+        """Getter for the report type"""
+        return self._report_type
+
     def __eq__(self, other):
         """Custom equality function"""
         if not isinstance(other, ReportSettings):
             return NotImplemented
 
-        return self._project_name == other._project_name and self._job_name == other._job_name
+        return (self.project_name == other.project_name
+                and self.job_name == other.job_name
+                and self.report_type == other.report_type)
 
     def __hash__(self):
         """Implement hash to allow objects to be used in sets and dicts"""
-        return hash((self._project_name, self._job_name))
+        return hash((self._project_name, self._job_name, self._report_type))

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -19,6 +19,7 @@ from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 from src.testproject.classes import StepSettings
 from src.testproject.enums import EnvironmentVariable
+from src.testproject.enums.report_type import ReportType
 from src.testproject.helpers import ReportHelper, LoggingHelper, ConfigHelper, AddonHelper
 from src.testproject.rest import ReportSettings
 from src.testproject.sdk.exceptions import SdkException
@@ -37,6 +38,7 @@ class BaseDriver(RemoteWebDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
 
     Attributes:
         _agent_client (AgentClient): client responsible for communicating with the TestProject agent
@@ -49,14 +51,8 @@ class BaseDriver(RemoteWebDriver):
 
     __instance = None
 
-    def __init__(
-        self,
-        capabilities: dict,
-        token: str,
-        project_name: str,
-        job_name: str,
-        disable_reports: bool,
-    ):
+    def __init__(self, capabilities: dict, token: str, project_name: str, job_name: str, disable_reports: bool,
+                 report_type: ReportType):
 
         if BaseDriver.__instance is not None:
             raise SdkException("A driver session already exists")
@@ -89,7 +85,7 @@ class BaseDriver(RemoteWebDriver):
         self._agent_client: AgentClient = AgentClient(
             token=self._token,
             capabilities=capabilities,
-            report_settings=ReportSettings(self._project_name, self._job_name),
+            report_settings=ReportSettings(self._project_name, self._job_name, report_type),
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/drivers/webdriver/chrome.py
+++ b/src/testproject/sdk/drivers/webdriver/chrome.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from selenium.webdriver import ChromeOptions
+
+from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
@@ -26,17 +28,13 @@ class Chrome(BaseDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
     """
 
-    def __init__(
-        self,
-        chrome_options: ChromeOptions = None,
-        desired_capabilities: dict = None,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, chrome_options: ChromeOptions = None, desired_capabilities: dict = None, token: str = None,
+                 project_name: str = None, job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
+
         # If no options or capabilities are specified at all, use default ChromeOptions
         if chrome_options is None and desired_capabilities is None:
             caps = ChromeOptions().to_capabilities()
@@ -54,4 +52,5 @@ class Chrome(BaseDriver):
             project_name=project_name,
             job_name=job_name,
             disable_reports=disable_reports,
+            report_type=report_type
         )

--- a/src/testproject/sdk/drivers/webdriver/edge.py
+++ b/src/testproject/sdk/drivers/webdriver/edge.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from selenium.webdriver.edge.options import Options
+
+from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
@@ -26,17 +28,13 @@ class Edge(BaseDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
     """
 
-    def __init__(
-        self,
-        edge_options: Options = None,
-        desired_capabilities: dict = None,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, edge_options: Options = None, desired_capabilities: dict = None, token: str = None,
+                 project_name: str = None, job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
+
         # If no options or capabilities are specified at all, use default Options
         if edge_options is None and desired_capabilities is None:
             caps = Options().to_capabilities()
@@ -54,4 +52,5 @@ class Edge(BaseDriver):
             project_name=project_name,
             job_name=job_name,
             disable_reports=disable_reports,
+            report_type=report_type
         )

--- a/src/testproject/sdk/drivers/webdriver/firefox.py
+++ b/src/testproject/sdk/drivers/webdriver/firefox.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from selenium.webdriver import FirefoxOptions
+
+from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
@@ -26,17 +28,13 @@ class Firefox(BaseDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
     """
 
-    def __init__(
-        self,
-        firefox_options: FirefoxOptions = None,
-        desired_capabilities: dict = None,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, firefox_options: FirefoxOptions = None, desired_capabilities: dict = None, token: str = None,
+                 project_name: str = None, job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
+
         # If no options or capabilities are specified at all, use default FirefoxOptions
         if firefox_options is None and desired_capabilities is None:
             caps = FirefoxOptions().to_capabilities()
@@ -54,4 +52,5 @@ class Firefox(BaseDriver):
             project_name=project_name,
             job_name=job_name,
             disable_reports=disable_reports,
+            report_type=report_type
         )

--- a/src/testproject/sdk/drivers/webdriver/generic.py
+++ b/src/testproject/sdk/drivers/webdriver/generic.py
@@ -18,6 +18,7 @@ import os
 from packaging import version
 
 from src.testproject.enums import EnvironmentVariable
+from src.testproject.enums.report_type import ReportType
 from src.testproject.helpers import ReportHelper, LoggingHelper, ConfigHelper, AddonHelper
 from src.testproject.rest import ReportSettings
 from src.testproject.rest.messages.agentstatusresponse import AgentStatusResponse
@@ -36,19 +37,15 @@ class Generic:
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
     """
 
     __instance = None
 
     MIN_GENERIC_DRIVER_SUPPORTED_VERSION = "0.64.40"
 
-    def __init__(
-        self,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, token: str = None, project_name: str = None, job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
         if Generic.__instance is not None:
             raise SdkException("A driver session already exists")
 
@@ -92,7 +89,7 @@ class Generic:
                 # Can update job name at runtime if not specified.
                 os.environ[EnvironmentVariable.TP_UPDATE_JOB_NAME.value] = "True"
 
-        report_settings = ReportSettings(self._project_name, self._job_name)
+        report_settings = ReportSettings(self._project_name, self._job_name, report_type)
 
         capabilities = {"platformName": "ANY"}
 

--- a/src/testproject/sdk/drivers/webdriver/ie.py
+++ b/src/testproject/sdk/drivers/webdriver/ie.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from selenium.webdriver.ie.options import Options
+
+from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
@@ -26,17 +28,12 @@ class Ie(BaseDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
     """
 
-    def __init__(
-        self,
-        ie_options: Options = None,
-        desired_capabilities: dict = None,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, ie_options: Options = None, desired_capabilities: dict = None, token: str = None,
+                 project_name: str = None, job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
         # If no options or capabilities are specified at all, use default Options
         if ie_options is None and desired_capabilities is None:
             caps = Options().to_capabilities()
@@ -54,4 +51,5 @@ class Ie(BaseDriver):
             project_name=project_name,
             job_name=job_name,
             disable_reports=disable_reports,
+            report_type=report_type
         )

--- a/src/testproject/sdk/drivers/webdriver/remote.py
+++ b/src/testproject/sdk/drivers/webdriver/remote.py
@@ -19,6 +19,7 @@ from appium.webdriver.webdriver import WebDriver as AppiumWebDriver
 
 from src.testproject.classes import StepSettings
 from src.testproject.enums import EnvironmentVariable
+from src.testproject.enums.report_type import ReportType
 from src.testproject.helpers import ReportHelper, LoggingHelper, ConfigHelper, AddonHelper
 from src.testproject.rest import ReportSettings
 from src.testproject.sdk.exceptions import SdkException
@@ -49,14 +50,9 @@ class Remote(AppiumWebDriver):
 
     __instance = None
 
-    def __init__(
-        self,
-        desired_capabilities: dict = None,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, desired_capabilities: dict = None, token: str = None, project_name: str = None,
+                 job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
         if Remote.__instance is not None:
             raise SdkException("A driver session already exists")
 
@@ -84,7 +80,7 @@ class Remote(AppiumWebDriver):
                 # Can update job name at runtime if not specified.
                 os.environ[EnvironmentVariable.TP_UPDATE_JOB_NAME.value] = "True"
 
-        report_settings = ReportSettings(self._project_name, self._job_name)
+        report_settings = ReportSettings(self._project_name, self._job_name, report_type)
 
         self._agent_client: AgentClient = AgentClient(
             token=self._token,

--- a/src/testproject/sdk/drivers/webdriver/safari.py
+++ b/src/testproject/sdk/drivers/webdriver/safari.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from selenium.webdriver import DesiredCapabilities
 
+from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
@@ -25,20 +26,17 @@ class Safari(BaseDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        report_type (ReportType): Type of report to produce - cloud, local or both.
     """
 
-    def __init__(
-        self,
-        desired_capabilities: dict = DesiredCapabilities.SAFARI,
-        token: str = None,
-        project_name: str = None,
-        job_name: str = None,
-        disable_reports: bool = False,
-    ):
+    def __init__(self, desired_capabilities: dict = DesiredCapabilities.SAFARI, token: str = None,
+                 project_name: str = None, job_name: str = None, disable_reports: bool = False,
+                 report_type: ReportType = ReportType.CLOUD_AND_LOCAL):
         super().__init__(
             capabilities=desired_capabilities,
             token=token,
             project_name=project_name,
             job_name=job_name,
             disable_reports=disable_reports,
+            report_type=report_type
         )

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -444,7 +444,8 @@ class AgentClient:
             )
         return payload
 
-    def __handle_new_session_error(self, response: OperationResult):
+    @staticmethod
+    def __handle_new_session_error(response: OperationResult):
         """ Handles errors occurring on creation of a new session with the Agent
 
         Args:

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -389,17 +389,13 @@ class AgentClient:
 
         # Send a final, empty, report to the queue to ensure that
         # the 'running' condition is evaluated one last time
-        self._queue.put(
-            QueueItem(report_as_json=None, url=None, token=self._token), block=False
-        )
+        self._queue.put(QueueItem(report_as_json=None, url=None, token=self._token), block=False)
 
         # Wait until all items have been reported or timeout passes
         self._reporting_thread.join(timeout=self.REPORTS_QUEUE_TIMEOUT)
         if self._reporting_thread.is_alive():
             # Thread is still alive, so there are unreported items
-            logging.warning(
-                f"There are {self._queue.qsize()} unreported items in the queue"
-            )
+            logging.warning(f"There are {self._queue.qsize()} unreported items in the queue")
 
         if not AgentClient.can_reuse_session():
             self._close_socket = True

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -500,12 +500,12 @@ class QueueItem:
         token (str): Token used to authenticate with the Agent
 
     Attributes:
-        _report_as_json (dict): JSON payload representing the item to be reported
-        _url (str): Agent endpoint the payload should be POSTed to
+        _report_as_json (Optional[dict]): JSON payload representing the item to be reported
+        _url (Optional[str]): Agent endpoint the payload should be POSTed to
         _token (str): Token used to authenticate with the Agent
     """
 
-    def __init__(self, report_as_json: dict, url: str, token: str):
+    def __init__(self, report_as_json: Optional[dict], url: Optional[str], token: str):
         self._report_as_json = report_as_json
         self._url = url
         self._token = token

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -19,6 +19,7 @@ import uuid
 from distutils.util import strtobool
 from enum import Enum, unique
 from http import HTTPStatus
+from typing import Optional
 from urllib.parse import urljoin
 
 import requests
@@ -29,6 +30,7 @@ from requests import HTTPError
 from src.testproject.classes import ActionExecutionResponse
 from src.testproject.classes.resultfield import ResultField
 from src.testproject.enums import ExecutionResultType
+from src.testproject.enums.report_type import ReportType
 from src.testproject.executionresults import OperationResult
 from src.testproject.helpers import ConfigHelper, SeleniumHelper
 from src.testproject.rest import ReportSettings
@@ -64,6 +66,7 @@ class AgentClient:
         _remote_address (str): The Agent endpoint
         _capabilities (dict): Additional options to be applied to the driver instance
         _agent_session (AgentSession): stores properties of the current agent session
+        _agent_response (SessionResponse): Session initialization response.
         _token (str): The development token used to authenticate with the Agent
         _report_settings (ReportSettings): Settings (project name, job name) to be included in the report
         _queue (queue.Queue): queue holding reports to be sent to Agent in separate thread
@@ -74,59 +77,70 @@ class AgentClient:
     # Minimum Agent version number that supports session reuse
     MIN_SESSION_REUSE_CAPABLE_VERSION = "0.64.20"
 
+    # Minimum Agent version that supports local reports.
+    MIN_LOCAL_REPORT_SUPPORTED_VERSION = "2.1.0"
+
     # Class variable containing the current known Agent version
     __agent_version: str = None
 
     def __init__(self, token: str, capabilities: dict, report_settings: ReportSettings):
-        self._remote_address = ConfigHelper.get_agent_service_address()
-        self._capabilities = capabilities
         self._agent_session = None
-        self._token = token
-        self._report_settings = report_settings
-        self._queue = queue.Queue()
-
-        self._running = True
-        self._reporting_thread = threading.Thread(
-            target=self.__report_worker, daemon=True
-        )
+        self._agent_response = None
         self._close_socket = False
+        self._remote_address = ConfigHelper.get_agent_service_address()
+        self._report_settings = report_settings
+        self._capabilities = capabilities
+        self._token = token
+        # Attempt to start the session
+        self.__start_session()
+        # Make sure local reports are supported
+        self.__verify_local_reports_supported(report_settings.report_type)
+        # Running after all is initialized successfully
+        self._running = True
+        # After session started and is running, start the reporting thread
+        self._queue = queue.Queue()
+        self._reporting_thread = threading.Thread(target=self.__report_worker, daemon=True)
         self._reporting_thread.start()
-
-        if not self.__start_session():
-            raise SdkException("Failed to start development mode session")
 
     @property
     def agent_session(self):
         """Getter for the Agent session object"""
         return self._agent_session
 
-    def __start_session(self) -> bool:
-        """Starts a new development session with the Agent
+    def __verify_local_reports_supported(self, report_type: ReportType):
+        """Verify that target Agent supports local reports, otherwise throw an exception.
 
-        Returns:
-            bool: True if the session started successfully, False otherwise
+        Args:
+            report_type (ReportType): Report type requested.
+
+        Raises:
+            AgentConnectException when local reports are not supported.
         """
+        if (report_type is ReportType.LOCAL
+                and version.parse(self.__agent_version) < version.parse(self.MIN_LOCAL_REPORT_SUPPORTED_VERSION)):
+            raise AgentConnectException(f'Target Agent version [{self.__agent_version}] doesn\'t support local reports.'
+                                        f' Upgrade the Agent to the latest version and try again.')
+
+    def __start_session(self):
+        """Starts a new development session with the Agent"""
         sdk_version = ConfigHelper.get_sdk_version()
 
         logging.info(f"SDK version: {sdk_version}")
 
-        start_session_response = self._request_session_from_agent()
+        self._request_session_from_agent()
 
-        AgentClient.__agent_version = start_session_response.agent_version
+        AgentClient.__agent_version = self._agent_response.agent_version
 
         self._agent_session = AgentSession(
-            start_session_response.server_address,
-            start_session_response.session_id,
-            start_session_response.dialect,
-            start_session_response.capabilities,
+            self._agent_response.server_address,
+            self._agent_response.session_id,
+            self._agent_response.dialect,
+            self._agent_response.capabilities,
         )
 
-        SocketManager.instance().open_socket(
-            self._remote_address, start_session_response.dev_socket_port
-        )
+        SocketManager.instance().open_socket(self._remote_address, self._agent_response.dev_socket_port)
 
         logging.info("Development session started...")
-        return True
 
     @staticmethod
     def can_reuse_session() -> bool:
@@ -142,11 +156,10 @@ class AgentClient:
             AgentClient.__agent_version
         ) >= version.parse(AgentClient.MIN_SESSION_REUSE_CAPABLE_VERSION)
 
-    def _request_session_from_agent(self) -> SessionResponse:
+    def _request_session_from_agent(self):
         """Creates and sends a session request object
 
-        Returns:
-            SessionResponse: object containing the response to the session request
+            Sets the SessionResponse: object containing the response to the session request
         """
         session_request = SessionRequest(self._capabilities, self._report_settings)
 
@@ -172,27 +185,15 @@ class AgentClient:
         if not response.passed:
             self.__handle_new_session_error(response)
 
-        # The generic driver returns a partial response, so we have to create some fields ourselves
-        session_id = response.data.get("sessionId", uuid.uuid4())
-
-        dialect = response.data.get("dialect")
-
-        capabilities = response.data.get("capabilities", {})
-
-        agent_version = response.data.get("version")
-
-        # If driver is Generic, supply None as the server address.
-        server_address = response.data.get("serverAddress")
-
-        start_session_response = SessionResponse(
+        self._agent_response = SessionResponse(
             dev_socket_port=response.data["devSocketPort"],
-            server_address=server_address,
-            session_id=session_id,
-            dialect=dialect,
-            capabilities=capabilities,
-            agent_version=agent_version,
+            server_address=response.data.get("serverAddress"),
+            session_id=response.data.get("sessionId", uuid.uuid4()),
+            dialect=response.data.get("dialect"),
+            capabilities=response.data.get("capabilities", {}),
+            agent_version=response.data.get("version"),
+            local_report=response.data.get("localReport")
         )
-        return start_session_response
 
     def update_job_name(self, job_name):
         """Sends HTTP request to Agent to update job name during runtime.
@@ -396,6 +397,9 @@ class AgentClient:
 
         if not AgentClient.can_reuse_session():
             self._close_socket = True
+
+        if self._agent_response.local_report:
+            logging.info(f'Execution Report: {self._agent_response.local_report}')
 
     def execute_proxy(self, action: ActionProxy) -> AddonExecutionResponse:
         """Sends a custom action to the Agent

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -16,6 +16,7 @@ import logging
 import queue
 import threading
 import uuid
+from distutils.util import strtobool
 from enum import Enum, unique
 from http import HTTPStatus
 from urllib.parse import urljoin
@@ -196,10 +197,10 @@ class AgentClient:
     def update_job_name(self, job_name):
         """Sends HTTP request to Agent to update job name during runtime.
 
-                Args:
-                    job_name (str): new job name to use for the current execution
-                """
-        if os.getenv("TP_UPDATE_JOB_NAME") == "True":
+        Args:
+            job_name (str): new job name to use for the current execution
+        """
+        if strtobool(os.getenv("TP_UPDATE_JOB_NAME")):
             logging.info(f"Updating job name to: {job_name}")
             try:
                 response = self.send_request(
@@ -207,14 +208,10 @@ class AgentClient:
                     urljoin(self._remote_address, Endpoint.DevelopmentSession.value),
                     {"jobName": job_name}
                 )
+                if not response.passed:
+                    logging.error("Failed to update job name")
             except requests.exceptions.RequestException:
-                logging.error(
-                    "Failed to update job name"
-                )
-            if not response.passed:
-                logging.error(
-                    "Failed to update job name"
-                )
+                logging.error("Failed to update job name")
 
     def send_request(self, method, path, body=None, params=None) -> OperationResult:
         """Sends HTTP request to Agent

--- a/tests/ci/unittests/rest/messages/drivercommandreport_test.py
+++ b/tests/ci/unittests/rest/messages/drivercommandreport_test.py
@@ -71,7 +71,7 @@ def test_to_json(dcr):
         "result": {"result": "value"},
         "passed": True,
         "screenshot": None,
-        "message": None
+        "message": None,
     }
 
 
@@ -82,5 +82,5 @@ def test_to_json_with_screenshot(dcr_with_screenshot):
         "result": {"result": "value"},
         "passed": False,
         "screenshot": "base64_screenshot",
-        "message": None
+        "message": None,
     }

--- a/tests/ci/unittests/rest/messages/sessionrequest_test.py
+++ b/tests/ci/unittests/rest/messages/sessionrequest_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from src.testproject.helpers import ConfigHelper
 from src.testproject.rest import ReportSettings
 from src.testproject.rest.messages import SessionRequest
@@ -31,4 +30,5 @@ def test_sessionrequest_to_json(mocker):
         "capabilities": {"key": "value"},
         "sdkVersion": "1.2.3.4",
         "language": "Python",
+        "reportType": "CLOUD_AND_LOCAL"
     }

--- a/tests/ci/unittests/rest/messages/sessionrequest_test.py
+++ b/tests/ci/unittests/rest/messages/sessionrequest_test.py
@@ -23,8 +23,8 @@ def test_sessionrequest_to_json(mocker):
     ConfigHelper.get_sdk_version.return_value = "1.2.3.4"
 
     capabilities = {"key": "value"}
-    reportsettings = ReportSettings("my_project", "my_job")
-    session_request = SessionRequest(capabilities, reportsettings)
+    report_settings = ReportSettings("my_project", "my_job")
+    session_request = SessionRequest(capabilities, report_settings)
     assert session_request.to_json() == {
         "projectName": "my_project",
         "jobName": "my_job",

--- a/tests/internal/cloud_local_reporting_test.py
+++ b/tests/internal/cloud_local_reporting_test.py
@@ -1,0 +1,31 @@
+from src.testproject.enums.report_type import ReportType
+from src.testproject.sdk.drivers import webdriver
+
+DEV_TOKEN = "YOUR_DEV_TOKEN"
+
+
+def test_local_report():
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Report Decorator Project", job_name="Report Decorator Job",
+                              report_type=ReportType.LOCAL)
+    driver.report().disable_command_reports(True)
+    driver.get(url='https://www.google.com')
+    driver.report().step("Local Report - Navigating to URL", "Navigating to Google", True)
+    driver.quit()
+
+
+def test_cloud_report():
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Report Decorator Project", job_name="Report Decorator Job",
+                              report_type=ReportType.CLOUD)
+    driver.report().disable_command_reports(True)
+    driver.get(url='https://www.google.com')
+    driver.report().step("Cloud Report - Navigating to URL", "Navigating to Google", True)
+    driver.quit()
+
+
+def test_cloud_and_local_report():
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Report Decorator Project", job_name="Report Decorator Job",
+                              report_type=ReportType.CLOUD_AND_LOCAL)
+    driver.report().disable_command_reports(True)
+    driver.get(url='https://www.google.com')
+    driver.report().step("Local AND Cloud Report - Navigating to URL", "Navigating to Google", True)
+    driver.quit()


### PR DESCRIPTION
When a local report is not supported - SDK will output:

Target Agent version [2.0.0] doesn't support local reports. Upgrade the Agent to the latest version and try again.

When local cloud is requested but Agent is offline, SDK will output:

Agent responded with status 412: [Agent is offline and is not able to upload the execution report to the cloud as requested]