### PR TITLE
Skip the build-test-publish job for ext prs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,7 @@ on:
 jobs:
   build-test-publish:
     # Do not run on PRs from forks
-    if: |
-      ${{ 
-        (github.event == 'push' && startsWith(github.ref, 'refs/heads/master')) ||
-        (github.event == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)  ||
-        (github.event.release.action == 'published')
-      }}
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
For external PRs (forks) run only the linting and offline pipelines.

Signed-off-by: Vitaly Bukhovsky <vitaly@testproject.io>