### PR TITLE
decorator to enable gherkin style reporting when using pytest_bdd

### DIFF
--- a/src/testproject/decorator/pytestBDD_reporter.py
+++ b/src/testproject/decorator/pytestBDD_reporter.py
@@ -1,0 +1,81 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from src.testproject.helpers.activesessionhelper import get_active_driver_instance
+from src.testproject.enums import EnvironmentVariable
+from decorator import decorator
+
+
+@decorator
+def pytestBDD_reporter(func, screenshot: bool = True, *args, **kwargs):
+    """Enables automatic logging of Gherkin syntax, including  a screenshot when screenshot argument is True, by default
+    screenshots are taken only when a step fails.
+    Args:
+            func: Original function decorated by the annotation.
+            screenshot (bool): True if a screenshot should be taken for each step, otherwise (False) only on failure.
+    """
+    if os.getenv("TPENABLED") == "False":
+        return pytestBDD_reporter
+
+    os.environ[EnvironmentVariable.TP_DISABLE_AUTO_REPORTING.value] = "True"
+
+    hook_name = func.__name__
+
+    if hook_name == "pytest_bdd_after_step":
+        driver = get_active_driver_instance()
+        step = args[3]
+        message = "{} {}".format(step.keyword, step.name)
+
+        report_step(driver=driver, step=step, screenshot=screenshot, message=message)
+
+    elif hook_name == "pytest_bdd_step_error":
+        driver = get_active_driver_instance()
+        step = args[3]
+        exception = args[6]
+        step.failed = True
+        message = "{} {}".format(type(exception).__name__, str(exception))
+
+        report_step(driver=driver, step=step, screenshot=screenshot, message=message)
+    elif hook_name == "pytest_bdd_after_scenario":
+        driver = get_active_driver_instance()
+        scenario = args[2]
+
+        report_test(driver=driver, scenario=scenario)
+
+    if func:
+        return pytestBDD_reporter(func)
+
+    return pytestBDD_reporter
+
+
+def report_step(driver, step, screenshot, message):
+    """Report pytest-bdd  step """
+    driver.report().disable_reports(False)
+    step_description = "{} {}".format(step.keyword, step.name)
+    driver.report().step(
+        description=step_description,
+        message=message,
+        passed=not step.failed,
+        screenshot=screenshot,
+    )
+    driver.report().disable_reports(True)
+
+
+def report_test(driver, scenario):
+    """Report pytest-bdd scenario """
+    driver.report().disable_reports(False)
+    test_name = scenario.name
+    driver.report().test(name=test_name, passed=not scenario.failed)
+    driver.report().disable_reports(True)
+    driver.report().disable_reports(True)

--- a/tests/examples/frameworks/pytest-bdd/conftest.py
+++ b/tests/examples/frameworks/pytest-bdd/conftest.py
@@ -1,0 +1,63 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.testproject.sdk.drivers import webdriver
+from src.testproject.decorator.pytestBDD_reporter import pytestBDD_reporter
+import pytest
+
+""" Executed after each succesful step in the scenario.
+    Reports the test step.
+"""
+
+
+@pytest.fixture(scope="class")
+def browser():
+    driver = webdriver.Chrome(project_name="Python BDD", job_name="Python BDD")
+    yield driver
+    driver.quit
+
+
+""" Executed after each succesful step in the scenario.
+    Reports the test step.
+"""
+
+
+@pytestBDD_reporter(screenshot=True)
+def pytest_bdd_after_step(request, feature, scenario, step, step_func, step_func_args):
+    pass
+
+
+""" Executed after each scenario in the feature.
+    Reports the scenario as a test.
+"""
+
+
+@pytestBDD_reporter
+def pytest_bdd_after_scenario(request, feature, scenario):
+    pass
+
+
+""" Executed once per test run: after all features and scenarios are run.
+    Quit the driver and close the session.
+"""
+
+
+@pytestBDD_reporter
+def pytest_bdd_step_error(request, feature, scenario, step, step_func, step_func_args, exception):
+    pass
+
+
+@pytestBDD_reporter
+def pytest_bdd_before_scenario(request, feature, scenario):
+    pass

--- a/tests/examples/frameworks/pytest-bdd/features/selenium_test.feature
+++ b/tests/examples/frameworks/pytest-bdd/features/selenium_test.feature
@@ -1,0 +1,20 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: TestProject with Behave Framework
+
+  Scenario: Run a Simple BDD test with TestProject
+     Given I navigate to the TestProject example page
+     When I perform a login
+     Then I should see a logout button

--- a/tests/examples/frameworks/pytest-bdd/steps/test_testproject.py
+++ b/tests/examples/frameworks/pytest-bdd/steps/test_testproject.py
@@ -1,0 +1,38 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pytest_bdd import scenario, given, when, then
+
+
+@scenario("../features/selenium_test.feature", "Run a Simple BDD test with TestProject")
+def test_testproject():
+    pass
+
+
+@given("I navigate to the TestProject example page")
+def step_impl_given(browser):
+    browser.get("https://example.testproject.io/web/")
+
+
+@when("I perform a login")
+def step_impl_when(browser):
+    browser.find_element_by_css_selector("#name").send_keys("John Smith")
+    browser.find_element_by_css_selector("#password").send_keys("12345")
+    browser.find_element_by_css_selector("#login").click()
+
+
+@then("I should see a logout button")
+def step_impl_then(browser):
+    passed = browser.find_element_by_css_selector("#logout").is_displayed()
+    assert passed is True


### PR DESCRIPTION
To enable the following functions have to be annotated in conftest.py:

@pytestBDD_reporter()
def pytest_bdd_after_step(request, feature, scenario, step, step_func,step_func_args):
	pass

@pytestBDD_reporter()
def pytest_bdd_after_scenario(request, feature, scenario):
	pass

@pytestBDD_reporter()
def pytest_bdd_step_error(request, feature, scenario, step, step_func, step_func_args, exception):
	pass

@pytestBDD_reporter()
def pytest_bdd_before_scenario(request, feature, scenario):
	pass

Signed-off-by: bbornhau <79279609+bbornhau@users.noreply.github.com>