### PR TITLE
Fix  agent session reuse logic

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ([#158](https://github.com/testproject-io/python-opensdk/pull/158)) - 
+  Fix for agent session reuse, tests with the Same Job and Project name will be under the same Report. 
+
 ## [1.0.0] - 2021-04-01
 
 ### Added

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -52,11 +52,12 @@ from src.testproject.sdk.exceptions import (
     ObsoleteVersionException,
 )
 from src.testproject.sdk.exceptions.addonnotinstalled import AddonNotInstalledException
+from src.testproject.sdk.internal.agent.agent_client_singleton import AgentClientSingleton
 from src.testproject.sdk.internal.session import AgentSession
 from src.testproject.tcp import SocketManager
 
 
-class AgentClient:
+class AgentClient(metaclass=AgentClientSingleton):
     """Client used to communicate with the TestProject Agent process
 
     Args:
@@ -108,6 +109,11 @@ class AgentClient:
     def agent_session(self):
         """Getter for the Agent session object"""
         return self._agent_session
+
+    @property
+    def report_settings(self) -> ReportSettings:
+        """Getter for the ReportSettings object"""
+        return self._report_settings
 
     def __verify_local_reports_supported(self, report_type: ReportType):
         """Verify that target Agent supports local reports, otherwise throw an exception.
@@ -377,14 +383,6 @@ class AgentClient:
         """Send all remaining report items in the queue to TestProject"""
         # Send a stop signal to the thread worker
         self._running = False
-
-        # TODO: Add proper session reuse logic.
-        # Reusing a session means using the same Agent Client for multiple tests,
-        # not just reusing the TCP socket connection.
-        # Until this will be implemented correctly, always close the TCP socket.
-
-        # if not AgentClient.can_reuse_session():
-        self._close_socket = True
 
         # Send a final, empty, report to the queue to ensure that
         # the 'running' condition is evaluated one last time

--- a/src/testproject/sdk/internal/agent/agent_client_singleton.py
+++ b/src/testproject/sdk/internal/agent/agent_client_singleton.py
@@ -1,0 +1,50 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.testproject.tcp import SocketManager
+
+
+class AgentClientSingleton(type):
+    """
+    Singleton class which defines the behaviour of getting and setting an AgentClient instance.
+    This class returns the instance of the AgentClient if it exists, as well as creates it if it does not,
+    it also checks if the agent dev session should be reused before returning the instance, for aggregating
+    test reports which use the same ReportSettings (Job and Project name).
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            # Create an instance of it does not exist
+            cls._instances[cls] = super(AgentClientSingleton, cls).__call__(*args, **kwargs)
+        else:
+            # An instance already exists, check if it has the same designated Job and Project name
+            input_settings = kwargs["report_settings"]
+            instance = cls._instances[cls]
+            report_settings = instance.report_settings
+
+            same_settings = True if input_settings is not None and input_settings == report_settings else False
+
+            # Stop the current instance, and submit the reports to the reports Queue
+            instance.stop()
+
+            if not same_settings or not instance.can_reuse_session():
+                # Close the socket, as the settings are not the same hence different reports need to be generated
+                SocketManager.instance().close_socket()
+
+            # Init the instance to start the new Test
+            instance.__init__(*args, **kwargs)
+
+        return cls._instances[cls]


### PR DESCRIPTION
Fix for the agent session reuse, tests with the same Job and Project name will be aggregated under the same Report.