### PR TITLE
Avoid reporting Class name if tests resides inside a Class with a pytest fixture

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ([#160](https://github.com/testproject-io/python-opensdk/issues/160) - 
+  Fix test reports if tests were in a Class, the Class name was reported instead of the method name.
 - ([#158](https://github.com/testproject-io/python-opensdk/pull/158)) - 
   Fix for agent session reuse, tests with the Same Job and Project name will be under the same Report. 
 

--- a/src/testproject/helpers/reporthelper.py
+++ b/src/testproject/helpers/reporthelper.py
@@ -111,14 +111,20 @@ class ReportHelper:
         """
         path_to_test_file = pytest_info.split(" ")[0].split("::")[0]
         if element_to_find == ReportNamingElement.Project:
-            # Return the path without base file name parsed as "package".s
-            return path_to_test_file[0 : path_to_test_file.rfind("/")].replace("/", ".")
+            # Return the path without base file name parsed as "package".
+            index = path_to_test_file.rfind("/")
+            if index == -1:
+                index = -3
+            return path_to_test_file[0:index].replace("/", ".")
         elif element_to_find == ReportNamingElement.Job:
             # Return the base file name without '.py' extension.
             head, tail = ntpath.split(path_to_test_file)
             return (tail or ntpath.basename(head)).split(".py")[0]
         elif element_to_find == ReportNamingElement.Test:
-            return pytest_info.rsplit(" ", maxsplit=1)[0].split("::")[1]
+            split_values = pytest_info.rsplit(" ", maxsplit=1)[0].split("::")
+            # Return the last value in the array, as it is the test name
+            index = len(split_values) - 1
+            return split_values[index]
         return None
 
     @classmethod


### PR DESCRIPTION
If tests were in a class, the class name was reported instead.
If the test class was in the root folder, the inferred project name was <testclass>.p

This is a fix for https://github.com/testproject-io/python-opensdk/issues/160
