### PR TITLE
feat: Allow reporting steps at batches from OpenSDK.

### DIFF
--- a/.github/ci/docker-compose.yml
+++ b/.github/ci/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   testproject-agent:
-    image: testproject/agent:latest
+    image: testproject/agent:3.0.5
     container_name: testproject-agent
     depends_on:
       - chrome

--- a/src/testproject/rest/messages/customtestreport.py
+++ b/src/testproject/rest/messages/customtestreport.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from src.testproject.rest.messages.reportitemtype import ReportItemType
+
+
 class CustomTestReport:
     """Payload object sent to the Agent when reporting a test.
 
@@ -64,4 +67,4 @@ class CustomTestReport:
 
     def to_json(self):
         """Generates a dict containing the JSON representation of the test payload"""
-        return {"name": self._name, "passed": self._passed, "message": self._message}
+        return {"name": self._name, "passed": self._passed, "message": self._message, "type": ReportItemType.Test.value}

--- a/src/testproject/rest/messages/drivercommandreport.py
+++ b/src/testproject/rest/messages/drivercommandreport.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from src.testproject.rest.messages.reportitemtype import ReportItemType
+
+
 class DriverCommandReport:
     """Payload object sent to the Agent when reporting a driver command.
 
@@ -102,6 +105,7 @@ class DriverCommandReport:
             "passed": self.passed,
             "message": self.message,
             "screenshot": self.screenshot,
+            "type": ReportItemType.Command.value,
         }
 
         return payload

--- a/src/testproject/rest/messages/reportitemtype.py
+++ b/src/testproject/rest/messages/reportitemtype.py
@@ -1,0 +1,21 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+
+class ReportItemType(Enum):
+    Command = "Command"
+    Step = "Step"
+    Test = "Test"

--- a/src/testproject/rest/messages/stepreport.py
+++ b/src/testproject/rest/messages/stepreport.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from src.testproject.rest.messages.reportitemtype import ReportItemType
 import uuid
 
 from src.testproject.classes import ElementSearchCriteria
@@ -68,6 +69,7 @@ class StepReport:
             "screenshot": self._screenshot,
             "inputParameters": self._input_params,
             "outputParameters": self._output_params,
+            "type": ReportItemType.Step.value,
         }
 
         return json

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -490,5 +490,6 @@ class Endpoint(Enum):
     ReportDriverCommand = "/api/development/report/command"
     ReportStep = "/api/development/report/step"
     ReportTest = "/api/development/report/test"
+    ReportBatch = "/api/development/report/batch"
     AddonExecution = "/api/addons/executions"
     GetStatus = "/api/status"

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -14,13 +14,11 @@
 
 import logging
 import queue
-import threading
 import uuid
 
 from distutils.util import strtobool
 from enum import Enum, unique
 from http import HTTPStatus
-from typing import Optional
 from urllib.parse import urljoin, urlparse, ParseResult
 
 import requests
@@ -53,6 +51,7 @@ from src.testproject.sdk.exceptions import (
 )
 from src.testproject.sdk.exceptions.addonnotinstalled import AddonNotInstalledException
 from src.testproject.sdk.internal.agent.agent_client_singleton import AgentClientSingleton
+from src.testproject.sdk.internal.agent.reports_queue import ReportsQueue
 from src.testproject.sdk.internal.session import AgentSession
 from src.testproject.tcp import SocketManager
 
@@ -75,8 +74,6 @@ class AgentClient(metaclass=AgentClientSingleton):
         _queue (queue.Queue): queue holding reports to be sent to Agent in separate thread
     """
 
-    REPORTS_QUEUE_TIMEOUT = 10
-
     # Minimum Agent version number that supports session reuse
     MIN_SESSION_REUSE_CAPABLE_VERSION = "0.64.20"
 
@@ -91,7 +88,6 @@ class AgentClient(metaclass=AgentClientSingleton):
         self._is_local_execution = True
         self._agent_session = None
         self._agent_response = None
-        self._close_socket = False
         self._remote_address = agent_url if agent_url is not None else ConfigHelper.get_agent_service_address()
         self.__check_local_execution()
         self._report_settings = report_settings
@@ -101,12 +97,8 @@ class AgentClient(metaclass=AgentClientSingleton):
         self.__start_session()
         # Make sure local reports are supported
         self.__verify_local_reports_supported(report_settings.report_type)
-        # Running after all is initialized successfully
-        self._running = True
-        # After session started and is running, start the reporting thread
-        self._queue = queue.Queue()
-        self._reporting_thread = threading.Thread(target=self.__report_worker, daemon=True)
-        self._reporting_thread.start()
+        # Create reports queue
+        self._reports_queue = ReportsQueue(token)
 
     @property
     def agent_session(self):
@@ -128,7 +120,7 @@ class AgentClient(metaclass=AgentClientSingleton):
             AgentConnectException when local reports are not supported.
         """
         if report_type is ReportType.LOCAL and version.parse(self.__agent_version) < version.parse(
-            self.MIN_LOCAL_REPORT_SUPPORTED_VERSION
+                self.MIN_LOCAL_REPORT_SUPPORTED_VERSION
         ):
             raise AgentConnectException(
                 f"Target Agent version [{self.__agent_version}] doesn't support local reports."
@@ -369,14 +361,9 @@ class AgentClient(metaclass=AgentClientSingleton):
         Args:
             driver_command_report: object containing the driver command to be reported
         """
-
-        queue_item = QueueItem(
-            report_as_json=driver_command_report.to_json(),
-            url=urljoin(self._remote_address, Endpoint.ReportDriverCommand.value),
-            token=self._token,
-        )
-
-        self._queue.put(queue_item, block=False)
+        self._reports_queue.submit(report_as_json=driver_command_report.to_json(),
+                                   url=urljoin(self._remote_address, Endpoint.ReportDriverCommand.value),
+                                   block=False)
 
     def report_step(self, step_report: StepReport):
         """Sends step report to the Agent
@@ -385,13 +372,9 @@ class AgentClient(metaclass=AgentClientSingleton):
             step_report (StepReport): object containing the step to be reported
         """
 
-        queue_item = QueueItem(
-            report_as_json=step_report.to_json(),
-            url=urljoin(self._remote_address, Endpoint.ReportStep.value),
-            token=self._token,
-        )
-
-        self._queue.put(queue_item, block=False)
+        self._reports_queue.submit(report_as_json=step_report.to_json(),
+                                   url=urljoin(self._remote_address, Endpoint.ReportStep.value),
+                                   block=False)
 
     def report_test(self, test_report: CustomTestReport):
         """Sends test report to the Agent
@@ -400,31 +383,9 @@ class AgentClient(metaclass=AgentClientSingleton):
             test_report (CustomTestReport): object containing the test to be reported
         """
 
-        queue_item = QueueItem(
-            report_as_json=test_report.to_json(),
-            url=urljoin(self._remote_address, Endpoint.ReportTest.value),
-            token=self._token,
-        )
-
-        self._queue.put(queue_item, block=False)
-
-    def stop(self):
-        """Send all remaining report items in the queue to TestProject"""
-        # Send a stop signal to the thread worker
-        self._running = False
-
-        # Send a final, empty, report to the queue to ensure that
-        # the 'running' condition is evaluated one last time
-        self._queue.put(QueueItem(report_as_json=None, url=None, token=self._token), block=False)
-
-        # Wait until all items have been reported or timeout passes
-        self._reporting_thread.join(timeout=self.REPORTS_QUEUE_TIMEOUT)
-        if self._reporting_thread.is_alive():
-            # Thread is still alive, so there are unreported items
-            logging.warning(f"There are {self._queue.qsize()} unreported items in the queue")
-
-        if self._agent_response.local_report and self._is_local_execution:
-            logging.info(f"Execution Report: {self._agent_response.local_report}")
+        self._reports_queue.submit(report_as_json=test_report.to_json(),
+                                   url=urljoin(self._remote_address, Endpoint.ReportTest.value),
+                                   block=False)
 
     def execute_proxy(self, action: ActionProxy) -> AddonExecutionResponse:
         """Sends a custom action to the Agent
@@ -510,63 +471,16 @@ class AgentClient(metaclass=AgentClientSingleton):
                 f"Agent responded with HTTP status {response.status_code}: [{response.message}]"
             )
 
-    def __report_worker(self):
-        """Worker method that is polling the queue for items to report"""
-        while self._running or self._queue.qsize() > 0:
-
-            item = self._queue.get()
-            if isinstance(item, QueueItem):
-                item.send()
-            else:
-                logging.warning(f"Unknown object of type {type(item)} found on queue, ignoring it..")
-            self._queue.task_done()
-        # Close socket only after agent_client is no longer running and all reports in the queue have been sent.
-        if self._close_socket:
-            SocketManager.instance().close_socket()
-
     def __check_local_execution(self):
         """Helper method which validates if the remote address supplied is local"""
         valid_hosts = ["127.0.0.1", "localhost", "0.0.0.0"]
         if urlparse(self._remote_address).hostname in valid_hosts:
             self._is_local_execution = True
 
-
-class QueueItem:
-    """Helper class representing an item to be reported
-
-    Args:
-        report_as_json (dict): JSON payload representing the item to be reported
-        url (str): Agent endpoint the payload should be POSTed to
-        token (str): Token used to authenticate with the Agent
-
-    Attributes:
-        _report_as_json (Optional[dict]): JSON payload representing the item to be reported
-        _url (Optional[str]): Agent endpoint the payload should be POSTed to
-        _token (str): Token used to authenticate with the Agent
-    """
-
-    def __init__(self, report_as_json: Optional[dict], url: Optional[str], token: str):
-        self._report_as_json = report_as_json
-        self._url = url
-        self._token = token
-
-    def send(self):
-        """Send a report item to the Agent"""
-        if self._report_as_json is None and self._url is None:
-            # Skip empty queue items put in the queue on stop()
-            return
-
-        with requests.Session() as session:
-            response = session.post(
-                self._url,
-                headers={"Authorization": self._token},
-                json=self._report_as_json,
-            )
-            try:
-                response.raise_for_status()
-            except HTTPError:
-                logging.error(f"Reporting to TestProject returned an HTTP {response.status_code}")
-                logging.error(f"Response from Agent: {response.text}")
+    def stop(self):
+        self._reports_queue.stop()
+        if self._agent_response.local_report and self._is_local_execution:
+            logging.info(f"Execution Report: {self._agent_response.local_report}")
 
 
 @unique

--- a/src/testproject/sdk/internal/agent/reports_queue.py
+++ b/src/testproject/sdk/internal/agent/reports_queue.py
@@ -1,0 +1,110 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+import threading
+import logging
+from src.testproject.tcp import SocketManager
+from typing import Optional
+import requests
+from requests import HTTPError
+
+
+class ReportsQueue:
+    REPORTS_QUEUE_TIMEOUT = 10
+
+    def __init__(self, token: str):
+        self._token = token
+        self._close_socket = False
+        # Running after all is initialized successfully
+        self._running = True
+        # After session started and is running, start the reporting thread
+        self._queue = queue.Queue()
+        self._reporting_thread = threading.Thread(target=self.__report_worker, daemon=True)
+        self._reporting_thread.start()
+
+    def submit(self, report_as_json: [dict], url: [str], block: [bool]):
+        queue_item = QueueItem(
+            report_as_json=report_as_json,
+            url=url,
+            token=self._token,
+        )
+        self._queue.put(queue_item, block=block)
+
+    def stop(self):
+        """Send all remaining report items in the queue to TestProject"""
+        # Send a stop signal to the thread worker
+        self._running = False
+
+        # Send a final, empty, report to the queue to ensure that
+        # the 'running' condition is evaluated one last time
+        self._queue.put(QueueItem(report_as_json=None, url=None, token=self._token), block=False)
+
+        # Wait until all items have been reported or timeout passes
+        self._reporting_thread.join(timeout=self.REPORTS_QUEUE_TIMEOUT)
+        if self._reporting_thread.is_alive():
+            # Thread is still alive, so there are unreported items
+            logging.warning(f"There are {self._queue.qsize()} unreported items in the queue")
+
+    def __report_worker(self):
+        """Worker method that is polling the queue for items to report"""
+        while self._running or self._queue.qsize() > 0:
+
+            item = self._queue.get()
+            if isinstance(item, QueueItem):
+                item.send()
+            else:
+                logging.warning(f"Unknown object of type {type(item)} found on queue, ignoring it..")
+            self._queue.task_done()
+        # Close socket only after agent_client is no longer running and all reports in the queue have been sent.
+        if self._close_socket:
+            SocketManager.instance().close_socket()
+
+
+class QueueItem:
+    """Helper class representing an item to be reported
+
+    Args:
+        report_as_json (dict): JSON payload representing the item to be reported
+        url (str): Agent endpoint the payload should be POSTed to
+        token (str): Token used to authenticate with the Agent
+
+    Attributes:
+        _report_as_json (Optional[dict]): JSON payload representing the item to be reported
+        _url (Optional[str]): Agent endpoint the payload should be POSTed to
+        _token (str): Token used to authenticate with the Agent
+    """
+
+    def __init__(self, report_as_json: Optional[dict], url: Optional[str], token: str):
+        self._report_as_json = report_as_json
+        self._url = url
+        self._token = token
+
+    def send(self):
+        """Send a report item to the Agent"""
+        if self._report_as_json is None and self._url is None:
+            # Skip empty queue items put in the queue on stop()
+            return
+
+        with requests.Session() as session:
+            response = session.post(
+                self._url,
+                headers={"Authorization": self._token},
+                json=self._report_as_json,
+            )
+            try:
+                response.raise_for_status()
+            except HTTPError:
+                logging.error(f"Failed to send a report to the Agent with HTTP error code {response.status_code}")
+                logging.error(f"Response from Agent: {response.text}")

--- a/src/testproject/sdk/internal/agent/reports_queue_batch.py
+++ b/src/testproject/sdk/internal/agent/reports_queue_batch.py
@@ -1,0 +1,63 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import logging
+import os
+from src.testproject.sdk.internal.agent.reports_queue import ReportsQueue, QueueItem
+
+
+class ReportsQueueBatch(ReportsQueue):
+    MAX_REPORT_BATCH_SIZE = 10
+    TP_MAX_BATCH_SIZE_VARIABLE_NAME = "TP_MAX_REPORTS_BATCH_SIZE"
+
+    def __init__(self, token: str, url: [str]):
+        super().__init__(token)
+        self._url = url
+        self.__batch_list = collections.deque()
+        """Get maximum reports batch size from environment variable."""
+        """If the environment variable is not defined - set maximum reports batch size to 10 as default"""
+        try:
+            env_var_value = os.environ[self.TP_MAX_BATCH_SIZE_VARIABLE_NAME]
+            if env_var_value is not None:
+                self.__max_batch_size = int(env_var_value)
+            else:
+                self.__max_batch_size = self.MAX_REPORT_BATCH_SIZE
+        except KeyError:
+            logging.warning("The environment variable {TP_MAX_BATCH_SIZE_VARIABLE_NAME} is not defined.")
+            self.__max_batch_size = self.MAX_REPORT_BATCH_SIZE
+        except ValueError:
+            logging.warning("The environment variable {TP_MAX_BATCH_SIZE_VARIABLE_NAME} value must be an integer.")
+            self.__max_batch_size = self.MAX_REPORT_BATCH_SIZE
+        except Exception:
+            self.__max_batch_size = self.MAX_REPORT_BATCH_SIZE
+        logging.info("The maximum reports batch size is defined as {self.__max_batch_size}.")
+
+    def _handle_report(self, item: [object]):
+        self.__batch_list.append(item.report_as_json)
+
+        if self.__batch_list.__len__() == 0:
+            return
+
+        """Send the reports batch, if one of the following conditions is true:"""
+        """The batch list size reached allowed maximum."""
+        """The queue is empty and the reports batch list is not."""
+        if self.__batch_list.__len__() == self.__max_batch_size or (
+            self.__batch_list.__len__() > 0 and self._queue.qsize() == 0
+        ):
+            """Convert reports linked list to a plain list before it's sent to the Agent"""
+            batch_json = list(self.__batch_list)
+            """Build QueueItem with reports batch json and send it to the agent"""
+            batch_item = QueueItem(url=self._url, report_as_json=batch_json, token=self._token)
+            batch_item.send()
+            self.__batch_list.clear()

--- a/tests/ci/unittests/rest/messages/customtestreport_test.py
+++ b/tests/ci/unittests/rest/messages/customtestreport_test.py
@@ -21,4 +21,5 @@ def test_to_json():
         "name": "my_name",
         "passed": True,
         "message": "my_message",
+        "type": "Test",
     }

--- a/tests/ci/unittests/rest/messages/drivercommandreport_test.py
+++ b/tests/ci/unittests/rest/messages/drivercommandreport_test.py
@@ -72,6 +72,7 @@ def test_to_json(dcr):
         "passed": True,
         "screenshot": None,
         "message": None,
+        "type": "Command",
     }
 
 
@@ -83,4 +84,5 @@ def test_to_json_with_screenshot(dcr_with_screenshot):
         "passed": False,
         "screenshot": "base64_screenshot",
         "message": None,
+        "type": "Command",
     }

--- a/tests/ci/unittests/rest/messages/stepreport_test.py
+++ b/tests/ci/unittests/rest/messages/stepreport_test.py
@@ -32,6 +32,7 @@ def test_to_json_without_screenshot(mocker):
         "inputParameters": None,
         "outputParameters": None,
         "screenshot": None,
+        "type": "Step",
     }
 
 
@@ -55,4 +56,5 @@ def test_to_json_with_screenshot(mocker):
         "inputParameters": None,
         "outputParameters": None,
         "screenshot": "base64_screenshot_here",
+        "type": "Step",
     }


### PR DESCRIPTION
Adding logic to support reporting at batches due to issue #179 
ReportsQueue class was added and methods related to the reports queue were extracted from AgentClient class.
ReportsQueueBatch was added to support up to 10 reports in a batch.
Logic added to AgentClient - to support the new ReportsQueue from agent version: 3.0.0