### PR TITLE
fix: check if token is in driver constructor before raising SdkException

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SDK will check if development token was provided in the driver constructor or as environment variable before rasing SdkException.
+
 ## [1.2.1] - 2021-07-08
 
 ### Added

--- a/src/testproject/helpers/confighelper.py
+++ b/src/testproject/helpers/confighelper.py
@@ -16,7 +16,6 @@ import os
 import logging
 
 from src.testproject import definitions
-from src.testproject.sdk.exceptions import SdkException
 
 
 class ConfigHelper:
@@ -52,14 +51,7 @@ class ConfigHelper:
         Returns:
             str: the developer token
         """
-        token = os.getenv("TP_DEV_TOKEN")
-        if token is None:
-            logging.error("No developer token was found, did you set it in the TP_DEV_TOKEN environment variable?")
-            logging.error(
-                "You can get a developer token from https://app.testproject.io/#/integrations/sdk?lang=Python"
-            )
-            raise SdkException("No development token defined in TP_DEV_TOKEN environment variable")
-        return token
+        return os.getenv("TP_DEV_TOKEN")
 
     @staticmethod
     def get_sdk_version() -> str:

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -73,14 +73,22 @@ class BaseDriver(RemoteWebDriver):
             raise SdkException("A driver session already exists")
 
         LoggingHelper.configure_logging()
-
-        if token is not None:
-            logging.info(f"Token used as specified in constructor: {token}")
-
         env_token = ConfigHelper.get_developer_token()
-        if env_token is not None and token is not None:
-            logging.info("Using token from environment variable...")
-        self._token = env_token if env_token is not None else token
+        if env_token is not None:
+            if token is not None:
+                logging.info(
+                    "Found TP_DEV_TOKEN environment variable. Using its value as the development token "
+                    "instead of the value in the driver constructor"
+                )
+            self._token = env_token
+        elif token is not None:
+            self._token = token
+        else:
+            logging.error("No developer token was found, did you set it in the TP_DEV_TOKEN environment variable?")
+            logging.error(
+                "You can get a developer token from https://app.testproject.io/#/integrations/sdk?lang=Python"
+            )
+            raise SdkException("No development token was provided")
 
         if disable_reports:
             # Setting the project and job name to empty strings will cause the Agent to not initialize a report

--- a/tests/ci/unittests/helpers/confighelper_test.py
+++ b/tests/ci/unittests/helpers/confighelper_test.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from urllib.parse import urljoin
 from src.testproject.helpers import ConfigHelper
-from src.testproject.sdk.exceptions import SdkException
 from src.testproject.sdk.internal.agent.agent_client import Endpoint
 
 
@@ -38,11 +35,10 @@ def test_agent_env_with_trailing_slash_is_handled_correctly(monkeypatch):
     assert urljoin(agent_address, Endpoint.DevelopmentSession.value) == "http://127.0.0.1:8585/api/development/session"
 
 
-def test_undefined_token_env_variable_leads_to_exception_raised(monkeypatch):
+def test_undefined_token_env_variable(monkeypatch):
     monkeypatch.delenv("TP_DEV_TOKEN", raising=False)
-    with pytest.raises(SdkException) as sdke:
-        ConfigHelper.get_developer_token()
-    assert str(sdke.value) == "No development token defined in TP_DEV_TOKEN environment variable"
+    token = ConfigHelper.get_developer_token()
+    assert token is None
 
 
 def test_predefined_token_env_variable_resolves_to_specified_value(monkeypatch):


### PR DESCRIPTION
This related to this issue: #181 
Signed-off-by: Artem Kuznetsov <artem.kuznetsov@testproject.io>