### PR TITLE
feat: retry send reports in case of failure

### DIFF
--- a/.github/ci/docker-compose.yml
+++ b/.github/ci/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - "8585:8585"
     - "8686:8686"
   chrome:
-    image: selenium/standalone-chrome:latest
+    image: selenium/standalone-chrome:91.0
     volumes:
       - /dev/shm:/dev/shm
     ports:


### PR DESCRIPTION
As part of the development of the #179 feature.
We've found that we are not retrying to send the reports in case of a failure while sending reports. 
This logic was added to the csharp-sdk and java-sdk. 
Adding this logic also to python-sdk.


Signed-off-by: oriddd <ori.dafna@testproject.io>