### PR TITLE
fix: make connection timeout with the agent configurable

### DIFF
--- a/.github/ci/docker-compose.yml
+++ b/.github/ci/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
     - "5555:4444"
   firefox:
-    image: selenium/standalone-firefox:latest
+    image: selenium/standalone-firefox:92.0
     volumes:
       - /dev/shm:/dev/shm
     ports:

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -44,6 +44,7 @@ class BaseDriver(RemoteWebDriver):
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
 
     Attributes:
         _agent_client (AgentClient): client responsible for communicating with the TestProject agent
@@ -67,6 +68,7 @@ class BaseDriver(RemoteWebDriver):
         agent_url: str,
         report_name: str,
         report_path: str,
+        socket_session_timeout: int,
     ):
 
         if BaseDriver.__instance is not None:
@@ -109,6 +111,7 @@ class BaseDriver(RemoteWebDriver):
             capabilities=capabilities,
             agent_url=agent_url,
             report_settings=ReportSettings(self._project_name, self._job_name, report_type, report_name, report_path),
+            socket_session_timeout=socket_session_timeout,
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/drivers/webdriver/chrome.py
+++ b/src/testproject/sdk/drivers/webdriver/chrome.py
@@ -16,6 +16,7 @@ from selenium.webdriver import ChromeOptions
 
 from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
+from src.testproject.sdk.internal.agent.agent_client import AgentClient
 
 
 class Chrome(BaseDriver):
@@ -29,6 +30,7 @@ class Chrome(BaseDriver):
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
     """
 
     def __init__(
@@ -43,6 +45,7 @@ class Chrome(BaseDriver):
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
 
         # If no options or capabilities are specified at all, use default ChromeOptions
@@ -62,4 +65,5 @@ class Chrome(BaseDriver):
             agent_url=agent_url,
             report_name=report_name,
             report_path=report_path,
+            socket_session_timeout=socket_session_timeout,
         )

--- a/src/testproject/sdk/drivers/webdriver/edge.py
+++ b/src/testproject/sdk/drivers/webdriver/edge.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from selenium.webdriver.edge.options import Options
+from src.testproject.sdk.internal.agent import AgentClient
 
 from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
@@ -29,6 +30,7 @@ class Edge(BaseDriver):
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
     """
 
     def __init__(
@@ -43,6 +45,7 @@ class Edge(BaseDriver):
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
 
         # If no options or capabilities are specified at all, use default Options
@@ -62,4 +65,5 @@ class Edge(BaseDriver):
             agent_url=agent_url,
             report_name=report_name,
             report_path=report_path,
+            socket_session_timeout=socket_session_timeout,
         )

--- a/src/testproject/sdk/drivers/webdriver/firefox.py
+++ b/src/testproject/sdk/drivers/webdriver/firefox.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from selenium.webdriver import FirefoxOptions
+from src.testproject.sdk.internal.agent import AgentClient
 
 from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
@@ -29,6 +30,7 @@ class Firefox(BaseDriver):
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
     """
 
     def __init__(
@@ -43,6 +45,7 @@ class Firefox(BaseDriver):
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
 
         # If no options or capabilities are specified at all, use default FirefoxOptions
@@ -62,4 +65,5 @@ class Firefox(BaseDriver):
             agent_url=agent_url,
             report_name=report_name,
             report_path=report_path,
+            socket_session_timeout=socket_session_timeout,
         )

--- a/src/testproject/sdk/drivers/webdriver/generic.py
+++ b/src/testproject/sdk/drivers/webdriver/generic.py
@@ -43,6 +43,7 @@ class Generic:
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
     """
 
     __instance = None
@@ -59,6 +60,7 @@ class Generic:
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
         if Generic.__instance is not None:
             raise SdkException("A driver session already exists")
@@ -105,6 +107,7 @@ class Generic:
             capabilities=capabilities,
             agent_url=agent_url,
             report_settings=report_settings,
+            socket_session_timeout=socket_session_timeout,
         )
 
         self._agent_session: AgentSession = self._agent_client.agent_session

--- a/src/testproject/sdk/drivers/webdriver/ie.py
+++ b/src/testproject/sdk/drivers/webdriver/ie.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from selenium.webdriver.ie.options import Options
+from src.testproject.sdk.internal.agent import AgentClient
 
 from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
@@ -29,6 +30,7 @@ class Ie(BaseDriver):
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
     """
 
     def __init__(
@@ -43,6 +45,7 @@ class Ie(BaseDriver):
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
         # If no options or capabilities are specified at all, use default Options
         if ie_options is None and desired_capabilities is None:
@@ -61,4 +64,5 @@ class Ie(BaseDriver):
             agent_url=agent_url,
             report_name=report_name,
             report_path=report_path,
+            socket_session_timeout=socket_session_timeout,
         )

--- a/src/testproject/sdk/drivers/webdriver/remote.py
+++ b/src/testproject/sdk/drivers/webdriver/remote.py
@@ -43,6 +43,7 @@ class Remote(AppiumWebDriver):
         project_name (str): Project name to report
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
 
     Attributes:
         _desired_capabilities (dict): Automation session desired capabilities and options
@@ -66,6 +67,7 @@ class Remote(AppiumWebDriver):
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
         if Remote.__instance is not None:
             raise SdkException("A driver session already exists")
@@ -100,6 +102,7 @@ class Remote(AppiumWebDriver):
             capabilities=self._desired_capabilities,
             agent_url=agent_url,
             report_settings=report_settings,
+            socket_session_timeout=socket_session_timeout,
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/drivers/webdriver/safari.py
+++ b/src/testproject/sdk/drivers/webdriver/safari.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from selenium.webdriver import DesiredCapabilities
+from src.testproject.sdk.internal.agent import AgentClient
 
 from src.testproject.enums.report_type import ReportType
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
@@ -27,6 +28,7 @@ class Safari(BaseDriver):
         job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
         report_type (ReportType): Type of report to produce - cloud, local or both.
+        socket_session_timeout (int): The connection timeout to the agent in milliseconds.
     """
 
     def __init__(
@@ -40,6 +42,7 @@ class Safari(BaseDriver):
         agent_url: str = None,
         report_name: str = None,
         report_path: str = None,
+        socket_session_timeout: int = AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS,
     ):
         super().__init__(
             capabilities=desired_capabilities,
@@ -51,4 +54,5 @@ class Safari(BaseDriver):
             agent_url=agent_url,
             report_name=report_name,
             report_path=report_path,
+            socket_session_timeout=socket_session_timeout,
         )


### PR DESCRIPTION
Let the user configure the timeout of the connection with the agent (in milliseconds)